### PR TITLE
Приведено в соответствие с новой версией relatedProperties

### DIFF
--- a/related/YaMap.php
+++ b/related/YaMap.php
@@ -24,7 +24,7 @@ class YaMap extends PropertyType
     public $name = "";
 
     public $height  = 400; //px
-    public $zomm    = 10; //px
+    public $zoom    = 10; //px
 
 
     public $updateLatName           = '';
@@ -47,7 +47,7 @@ class YaMap extends PropertyType
         return array_merge(parent::attributeLabels(),
         [
             'height'                => "Высота карты",
-            'zomm'                  => "Пришлижение карты",
+            'zoom'                  => "Приближение карты",
             'updateLatName'         => "Обновлять latitude",
             'updateLonName'         => "Обновлять longitude",
             'updateAddressName'     => "Обновлять поле адрес",
@@ -59,7 +59,7 @@ class YaMap extends PropertyType
         return ArrayHelper::merge(parent::rules(),
         [
             ['height', 'integer'],
-            ['zomm', 'integer'],
+            ['zoom', 'integer'],
             ['updateLatName', 'string'],
             ['updateLonName', 'string'],
             ['updateAddressName', 'string'],
@@ -71,7 +71,7 @@ class YaMap extends PropertyType
     public function renderConfigForm(ActiveForm $activeForm)
     {
         echo $activeForm->field($this, 'height');
-        echo $activeForm->field($this, 'zomm');
+        echo $activeForm->field($this, 'zoom');
         echo $activeForm->field($this, 'updateLatName');
         echo $activeForm->field($this, 'updateLonName');
         echo $activeForm->field($this, 'updateAddressName');
@@ -100,7 +100,7 @@ class YaMap extends PropertyType
                 [
                     'ya' =>
                     [
-                        'zomm' => $this->zomm
+                        'zoom' => $this->zoom
                     ]
                 ]
             ]

--- a/related/YaMap.php
+++ b/related/YaMap.php
@@ -25,6 +25,7 @@ class YaMap extends PropertyType
 
     public $height  = 400; //px
     public $zoom    = 10; //px
+    public $center  = '55.75241746329202,37.62104013208003';
 
 
     public $updateLatName           = '';
@@ -48,6 +49,7 @@ class YaMap extends PropertyType
         [
             'height'                => "Высота карты",
             'zoom'                  => "Приближение карты",
+            'center'                => "Координаты по умолчанию (широта,долгота)",
             'updateLatName'         => "Обновлять latitude",
             'updateLonName'         => "Обновлять longitude",
             'updateAddressName'     => "Обновлять поле адрес",
@@ -60,6 +62,7 @@ class YaMap extends PropertyType
         [
             ['height', 'integer'],
             ['zoom', 'integer'],
+            ['center', 'string'],
             ['updateLatName', 'string'],
             ['updateLonName', 'string'],
             ['updateAddressName', 'string'],
@@ -72,6 +75,7 @@ class YaMap extends PropertyType
     {
         echo $activeForm->field($this, 'height');
         echo $activeForm->field($this, 'zoom');
+        echo $activeForm->field($this, 'center');
         echo $activeForm->field($this, 'updateLatName');
         echo $activeForm->field($this, 'updateLonName');
         echo $activeForm->field($this, 'updateAddressName');
@@ -88,6 +92,12 @@ class YaMap extends PropertyType
         $field = parent::renderForActiveForm();
         $mapId = 'sx-map-' . $field->attribute;
 
+        $center = explode(',', $this->center);
+        $center = array_map('trim', $center);
+        if(count($center)!==2) {
+            $center = [55.75241746329202,37.62104013208003]; // default city
+        }
+
         $field->widget(YaMapInput::className(), [
             'YaMapWidgetOptions' =>
             [
@@ -100,7 +110,8 @@ class YaMap extends PropertyType
                 [
                     'ya' =>
                     [
-                        'zoom' => $this->zoom
+                        'zoom' => $this->zoom,
+                        'center' => $center,
                     ]
                 ]
             ]

--- a/related/YaMap.php
+++ b/related/YaMap.php
@@ -109,19 +109,19 @@ class YaMap extends PropertyType
         $opts['updateLatId'] = '';
         if ($this->updateLatName)
         {
-            $opts['updateLatId'] = Html::getInputId($this->model->relatedPropertiesModel, $this->updateLatName);
+            $opts['updateLatId'] = Html::getInputId($this->property->relatedPropertiesModel, $this->updateLatName);
         }
 
         $opts['updateLonId'] = '';
         if ($this->updateLonName)
         {
-            $opts['updateLonId'] = Html::getInputId($this->model->relatedPropertiesModel, $this->updateLonName);
+            $opts['updateLonId'] = Html::getInputId($this->property->relatedPropertiesModel, $this->updateLonName);
         }
 
         $opts['updateAddressId'] = '';
-        if ($this->updateLonName)
+        if ($this->updateAddressName)
         {
-            $opts['updateAddressId'] = Html::getInputId($this->model->relatedPropertiesModel, $this->updateAddressName);
+            $opts['updateAddressId'] = Html::getInputId($this->property->relatedPropertiesModel, $this->updateAddressName);
         }
 
         $opts['mapId'] = $mapId;


### PR DESCRIPTION
Исправляет баг #2 
1. Исправлено: Поле skeeks\cms\relatedProperties\PropertyType->model более не существует после коммита skeeks-cms/cms@ce38dde5751bb97a6adae89f516356c3b4c15bdc от  12 Sep 2016
2. Исправлено последствие копипастинга для  ` if ($this->updateAddressName)`